### PR TITLE
correct wrong spelling of "Key" 

### DIFF
--- a/MicrobitPiano.ts
+++ b/MicrobitPiano.ts
@@ -58,7 +58,7 @@ enum RGB_COLOR {
 //% weight=20 color=#3333FF icon="\uf001"
 namespace MicrobitPiano {
     //% blockId=tp_press 
-    //% block="Pey|%index|is pressed"
+    //% block="Key|%index|is pressed"
     //% weight=100
     export function TP_Press(index: TP_PIANO): boolean {
         let TPval = pins.i2cReadNumber(0x57, NumberFormat.UInt16BE);


### PR DESCRIPTION
line 77 "Key" wrongly spelled as "Pey"